### PR TITLE
luarocks install fails

### DIFF
--- a/rockspecs/jmespath-0.1-1.rockspec
+++ b/rockspecs/jmespath-0.1-1.rockspec
@@ -1,5 +1,5 @@
 package = 'jmespath'
-version = '0.1-0'
+version = '0.1-1'
 
 source = {
    url = 'git://github.com/jmespath/jmespath.lua',
@@ -19,5 +19,7 @@ dependencies = {
 
 build = {
    type = 'builtin',
-   modules = {jmespath = 'jmespath.lua'}
+   modules = {
+     ['jmespath'] = 'jmespath.lua/jmespath.lua'
+   }
 }


### PR DESCRIPTION
Attempting to install with luarocks 2.3.0 and lua 5.1.5 results in a failure, complaining the source to copy is a directory and not a file.

```
$ luarocks install --tree lua_modules jmespath
Installing https://luarocks.org/jmespath-0.1-0.src.rock...
Using https://luarocks.org/jmespath-0.1-0.src.rock... switching to 'build' mode
cp: jmespath.lua is a directory (not copied).

Error: Build error: Failed installing jmespath.lua in /Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lua/jmespath.lua
```
To diagnose, I created a local copy of the rockspec and began messing around with it. The verbose output of attempting to install from my local rockspec is below. (Same result.)

```
$ luarocks install --tree lua_modules --verbose ~/Desktop/jmespath-0.1-0.rockspec

io.popen: 	'pwd' 2> /dev/null

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0
Using /Users/clay/Desktop/jmespath-0.1-0.rockspec... switching to 'build' mode

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/project/lua_modules'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-e' '/Users/clay/Desktop/jmespath-0.1-0.rockspec'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0'
Results: 1
  1 (number): 256

os.execute: 	cd '/Users/clay/project' && 'git' '--version'
git version 2.13.0
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && mkdir -p '/tmp/luarocks_jmespath-0.1-0-4905'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/tmp/luarocks_jmespath-0.1-0-4905'
Results: 1
  1 (number): 0

io.popen: 	'git' --version

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905' && 'git' 'clone' '--branch=0.1.0' '--depth=1' 'git://github.com/jmespath/jmespath.lua' 'jmespath.lua'
Cloning into 'jmespath.lua'...
remote: Counting objects: 33, done.
remote: Compressing objects: 100% (29/29), done.
remote: Total 33 (delta 6), reused 17 (delta 3), pack-reused 0
Receiving objects: 100% (33/33), 26.21 KiB | 0 bytes/s, done.
Resolving deltas: 100% (6/6), done.
Note: checking out 'b27688d0efcbceb64efd08dd2feada6093a3c037'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905' && test '-d' 'jmespath.lua'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/jmespath.lua' && rm '-rf' '/tmp/luarocks_jmespath-0.1-0-4905/jmespath.lua/.git'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/jmespath.lua' && rm '-rf' '/tmp/luarocks_jmespath-0.1-0-4905/jmespath.lua/.gitignore'
Results: 1
  1 (number): 0

os.execute: 	cd '/Users/clay/project' && test '-d' '/tmp/luarocks_jmespath-0.1-0-4905'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905' && test '-d' '.'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && mkdir -p '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/bin'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && mkdir -p '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lib'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && mkdir -p '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lua'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && mkdir -p '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/conf'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && mkdir -p '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lua'
Results: 1
  1 (number): 0

os.execute: 	cd '/tmp/luarocks_jmespath-0.1-0-4905/.' && cp 'jmespath.lua' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lua/jmespath.lua'
cp: jmespath.lua is a directory (not copied).
Results: 1
  1 (number): 256

os.execute: 	cd '/' && rm '-rf' '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0'
Results: 1
  1 (number): 0

os.execute: 	cd '/' && rmdir '/Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath'
Results: 1
  1 (number): 0

os.execute: 	cd '/' && rm '-rf' '/tmp/luarocks_jmespath-0.1-0-4905'
Results: 1
  1 (number): 0

Error: Build error: Failed installing jmespath.lua in /Users/clay/project/lua_modules/lib/luarocks/rocks-5.1/jmespath/0.1-0/lua/jmespath.lua
```

Making the change in the attached PR resulted in a clean installation.